### PR TITLE
Add textlint-tester to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "espower-babel": "^3.3.0",
     "mocha": "^2.3.2",
     "power-assert": "^1.0.0",
-    "textlint": "^6.0.1"
+    "textlint": "^6.0.1",
+    "textlint-tester": "^1.2.0"
   },
   "peerDependencies": {
     "textlint": ">= 5.5.0"


### PR DESCRIPTION
Without this, `npm test` fails with a message `Error: Cannot find
module 'textlint-tester'`.