### PR TITLE
Report error correctly when pattern starts with expected value

### DIFF
--- a/src/prh-rule.js
+++ b/src/prh-rule.js
@@ -77,8 +77,8 @@ function reporter(context, options = {}) {
                 // | ----[match------|
                 var matchedText = slicedText.slice(0, changeSet.matches[0].length);
                 var expected = matchedText.replace(changeSet.pattern, changeSet.expected);
-                // Avoid accidental match(ignore case, expected contain actual pattern)
-                if (slicedText.indexOf(expected) === 0) {
+                // Avoid accidental match(ignore case)
+                if (matchedText === expected) {
                     return;
                 }
                 /*

--- a/test/fixtures/rule.yaml
+++ b/test/fixtures/rule.yaml
@@ -48,9 +48,11 @@ rules:
         to:   日経ソフトウエア
 
   - expected: ベンダー
-    pattern: ベンダ
+    pattern: /ベンダ(?!ー)/
     specs:
       - from: ベンダ
+        to: ベンダー
+      - from: ベンダー
         to: ベンダー
 # 単語境界の区別
   - expected: js
@@ -65,3 +67,7 @@ rules:
       # 日本語+単語境界の仕様は自分で調べてね…！
       - from: 今日もJS祭り
         to:   今日もjs祭り
+
+  # 全角括弧前後の空白を除去
+  - expected: ）
+    pattern: /） | ）/

--- a/test/prh-rule-test.js
+++ b/test/prh-rule-test.js
@@ -25,6 +25,15 @@ describe("prh-rule-test", function () {
             });
         });
     });
+    context("when match word and s/） /）/ pattern", function () {
+        it("should report error", function () {
+            return textlint.lintMarkdown("（図1） ").then(result => {
+                assert(result.messages.length > 0);
+                assert(result.messages[0].line === 1);
+                assert(result.messages[0].column === 4);
+            });
+        });
+    });
     context("when match word but s/Web/Web/i pattern", function () {
         // fix ignore (the) case
         it("should not report", function () {


### PR DESCRIPTION
## Problem

textlint-rule-prh does not report an error with a text `"（図1） "` and the following rule:

```yml
  # 全角括弧前後の空白を除去
  - expected: ）
    pattern: /） | ）/
```

Note: prh does fix the error with this rule.

## Cause

This is because the [following condition](https://github.com/azu/textlint-rule-prh/blob/0f1243fc3268df6c7bfefe4070f599133b9539cc/src/prh-rule.js#L81) incorrectly ignore the error.

```js
               // Avoid accidental match(ignore case, expected contain actual pattern)
               if (slicedText.indexOf(expected) === 0) {
                   return;
               }
```

In this case, variables have the following values.

* `slicedText`:  `'） '`
* `matchedText`: `'） '`
* `expected`:    `'）'`

I understand that the condition is introduced by https://github.com/azu/textlint-rule-prh/commit/f528e780567b4cf1584182d773f3b2d499c5ac6f and https://github.com/azu/textlint-rule-prh/commit/cd739dc232e4108430bc2009a9fbb690e3dcbd88 to fix `s/Web/Web/i` problem and `s/ベンダ/ベンダー/` problem. But prh itself does not handle `s/ベンダ/ベンダー/` problem, i.e. prh corrects `ベンダー` to `ベンダーー`. So, I think `s/ベンダ/ベンダー/` problem should be handled by rule (or changing prh's behavior). I believe incompatibility between prh and textlint-rule-prh is confusing.

## Implementation

* Handle only `s/Web/Web/i` problem by code.
* Handle `s/ベンダ/ベンダー/` problem by rule.

This fix the `s/） /）/` problem.

I'll send another PR to [web+db_press.yml](https://github.com/azu/textlint-rule-web-plus-db/blob/master/dict/web%2Bdb_press.yml) to fix some patterns if this one is merged.