### PR TITLE
fix: correct `?=` RegExp

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   ],
   "dependencies": {
     "prh": "^1.0.1",
-    "structured-source": "^3.0.2",
     "textlint-rule-helper": "^2.0.0",
     "untildify": "^3.0.2"
   },

--- a/src/prh-rule.js
+++ b/src/prh-rule.js
@@ -66,12 +66,13 @@ const applyChangeSet = (changeSet, str, onReplace) => {
         });
         // use start/end value is original position, not replaced position
         // textlint use original position
-        const start = diff.index;
-        const end = start + diff.matches[0].length;
-        const actual = str.slice(start, end);
+        const matchStartIndex = diff.index;
+        const matchEndIndex = matchStartIndex + diff.matches[0].length;
+        // replaced
+        const actual = str.slice(diff.index + delta, diff.index + delta + diff.matches[0].length);
         onReplace({
-            start,
-            end,
+            matchStartIndex,
+            matchEndIndex,
             actual: actual,
             expected: result
         });
@@ -103,15 +104,14 @@ function reporter(context, options = {}) {
             // to get position from index
             let src = new StructuredSource(text);
             let makeChangeSet = prhEngine.makeChangeSet(null, text);
-            applyChangeSet(makeChangeSet, text, ({start, end, actual, expected}) => {
+            applyChangeSet(makeChangeSet, text, ({matchStartIndex, matchEndIndex, actual, expected}) => {
                 // If result is not changed, should not report
                 if (actual === expected) {
                     return;
                 }
-                console.log(start, end, actual, expected);
                 report(node, new RuleError(actual + " => " + expected, {
-                    index: start,
-                    fix: fixer.replaceTextRange([start, end], expected)
+                    index: matchStartIndex,
+                    fix: fixer.replaceTextRange([matchStartIndex, matchEndIndex], expected)
                 }));
             });
         }

--- a/test/fixtures/example-prh.yml
+++ b/test/fixtures/example-prh.yml
@@ -1,0 +1,79 @@
+version: 1
+
+rules:
+
+  # 大文字小文字全角半角の統一
+  - expected: Cookie
+  # 以下と等価 正規表現には強制でgフラグが付く
+  # - expected: Cookie
+  #   pattern: "/[CcＣｃ][OoＯｏ][OoＯｏ][KkＫｋ][IiＩｉ][EeＥｅ]/g"
+  #   options:
+  #     wordBoundary: false
+  #   specs: []
+
+  # 変換結果についてテストも書ける
+  - expected: jQuery
+    specs:
+      - from: jquery
+        to:   jQuery
+      - from: ＪＱＵＥＲＹ
+        to:   jQuery
+
+  # 変換結果が期待通りではなかった場合、ルールのロードに失敗する つまり、ルールのテストが書ける
+  # - expected: JavaScript
+  #   specs:
+  #     - from: JAVASCRIPT
+  #       to:   JavaScprit # この場合はテスト側が間違ってる！
+  # Error: JavaScript spec failed. "JAVASCRIPT", expected "JavaScprit", but got "JavaScript", /[JjＪｊ][AaＡａ][VvＶｖ][AaＡａ][SsＳｓ][CcＣｃ][RrＲｒ][IiＩｉ][PpＰｐ][TtＴｔ]/g
+
+  # 表現の統一を図る
+  - expected: デフォルト
+    pattern:  ディフォルト
+
+  # patternは複数記述可能 patterns としてもOK
+  - expected: ハードウェア
+    patterns:
+      - ハードウエアー # 正規表現に変換する都合上、より長いものを先に書いたほうがよい
+      - ハードウェアー
+      - ハードウエア
+
+  # patternには正規表現が利用可能
+  - expected: （$1）
+    pattern:  /\(([^)]+)\)/
+    specs:
+      # 半角括弧を全角括弧へ
+      - from: (そのとおり)
+        to:   （そのとおり）
+
+  # 否定戻り先読みが欲しいがJSにはない… regexpMustEmptyで、特定のキャプチャグループが空であることを指定して代用とする
+  - expected: ソフトウェア
+    pattern:  /(日経)?ソフトウエア/
+    regexpMustEmpty: $1
+    specs:
+      # 普通に変換
+      - from: 広義のソフトウエア
+        to:   広義のソフトウェア
+      # 日経ソフトウエア(書名)は変換しない
+      - from: 日経ソフトウエア
+        to:   日経ソフトウエア
+
+  # 長音の統一には否定後読みを活用する そうしないと サーバー が サーバーー にされてしまったりする
+  - expected: サーバー
+    pattern:  /サーバ(?!ー)/
+    specs:
+      - from: サーバ
+        to:   サーバー
+
+  # 単語境界の区別
+  - expected: js
+  # pattern: "/\b[JjＪｊ][SsＳｓ]\b/g" # と等価 \b が前後に付与される
+    options:
+      wordBoundary: true
+    specs:
+      - from: foo JS bar
+        to:   foo js bar
+      - from: foo altJS bar
+        to:   foo altJS bar
+      # 日本語+単語境界の仕様は自分で調べてね…！
+      - from: 今日もJS祭り
+        to:   今日もjs祭り

--- a/test/fixtures/prefer-regexp.yml
+++ b/test/fixtures/prefer-regexp.yml
@@ -2,10 +2,6 @@ version: 1
 
 rules:
   - prh: 「行う」「行なう」は開く。
-    # textlint ログにレポートされる
-    # pattern: '/(おこな|行な?)([わいっうえお])/g'
-    # expected: おこな$2
-    # textlint ログにレポートされない
     expected: おこな
     pattern: /(おこな|行な?)(?=[わいっうえお])/
     specs:

--- a/test/fixtures/prefer-regexp.yml
+++ b/test/fixtures/prefer-regexp.yml
@@ -1,0 +1,26 @@
+version: 1
+
+rules:
+  - prh: 「行う」「行なう」は開く。
+    # textlint ログにレポートされる
+    # pattern: '/(おこな|行な?)([わいっうえお])/g'
+    # expected: おこな$2
+    # textlint ログにレポートされない
+    expected: おこな
+    pattern: /(おこな|行な?)(?=[わいっうえお])/
+    specs:
+      - from: 行わない
+        to: おこなわない
+      - from: 行います
+        to: おこないます
+      - from: 行うとき
+        to: おこなうとき
+      - from: 行えば
+        to: おこなえば
+      - from: 行なう
+        to: おこなう
+      - from: おこなう
+        to: おこなう
+      # チェックされなくてよい部分
+      - from: 行く
+        to: 行く

--- a/test/prh-rule-tester-test.js
+++ b/test/prh-rule-tester-test.js
@@ -126,6 +126,96 @@ tester.run("prh", rule, {
                     }
                 }
             ]
+        },
+        // example-prh.yml
+        {
+            text: "jqueryではクッキー。ディフォルトとハードウエアー。(そのとおり)\nサーバはサーバーサイドをjsする。",
+            output: "jQueryではクッキー。デフォルトとハードウェア。（そのとおり）\nサーバーはサーバーサイドをjsする。",
+            options: {
+                "rulePaths": [__dirname + "/fixtures/example-prh.yml"]
+            },
+            errors: [
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "jquery => jQuery",
+                    "index": 0,
+                    "line": 1,
+                    "column": 1,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            0,
+                            6
+                        ],
+                        "text": "jQuery"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "ディフォルト => デフォルト",
+                    "index": 13,
+                    "line": 1,
+                    "column": 14,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            13,
+                            19
+                        ],
+                        "text": "デフォルト"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "ハードウエアー => ハードウェア",
+                    "index": 20,
+                    "line": 1,
+                    "column": 21,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            20,
+                            27
+                        ],
+                        "text": "ハードウェア"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "(そのとおり) => （そのとおり）",
+                    "index": 28,
+                    "line": 1,
+                    "column": 29,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            28,
+                            35
+                        ],
+                        "text": "（そのとおり）"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "サーバ => サーバー",
+                    "index": 36,
+                    "line": 2,
+                    "column": 1,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            36,
+                            39
+                        ],
+                        "text": "サーバー"
+                    }
+                }
+            ]
         }
     ]
 });

--- a/test/prh-rule-tester-test.js
+++ b/test/prh-rule-tester-test.js
@@ -44,7 +44,104 @@ tester.run("prh", rule, {
             options: {
                 "rulePaths": [__dirname + "/fixtures/prefer-regexp.yml"]
             },
-            errors: [/* TODO */]
+            errors: [
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "行 => おこな",
+                    "index": 0,
+                    "line": 1,
+                    "column": 1,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            0,
+                            1
+                        ],
+                        "text": "おこな"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "う、 => おこな",
+                    "index": 3,
+                    "line": 1,
+                    "column": 4,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            3,
+                            5
+                        ],
+                        "text": "おこな"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "なう、 => おこな",
+                    "index": 7,
+                    "line": 1,
+                    "column": 8,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            7,
+                            10
+                        ],
+                        "text": "おこな"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "な => おこな",
+                    "index": 12,
+                    "line": 1,
+                    "column": 13,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            12,
+                            13
+                        ],
+                        "text": "おこな"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "こ => おこな",
+                    "index": 16,
+                    "line": 1,
+                    "column": 17,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            16,
+                            17
+                        ],
+                        "text": "おこな"
+                    }
+                },
+                {
+                    "type": "lint",
+                    "ruleId": "prh",
+                    "message": "おこ => おこな",
+                    "index": 21,
+                    "line": 1,
+                    "column": 22,
+                    "severity": 2,
+                    "fix": {
+                        "range": [
+                            21,
+                            23
+                        ],
+                        "text": "おこな"
+                    }
+                }
+            ]
         }
     ]
 });

--- a/test/prh-rule-tester-test.js
+++ b/test/prh-rule-tester-test.js
@@ -64,7 +64,7 @@ tester.run("prh", rule, {
                 {
                     "type": "lint",
                     "ruleId": "prh",
-                    "message": "う、 => おこな",
+                    "message": "行な => おこな",
                     "index": 3,
                     "line": 1,
                     "column": 4,
@@ -80,23 +80,7 @@ tester.run("prh", rule, {
                 {
                     "type": "lint",
                     "ruleId": "prh",
-                    "message": "なう、 => おこな",
-                    "index": 7,
-                    "line": 1,
-                    "column": 8,
-                    "severity": 2,
-                    "fix": {
-                        "range": [
-                            7,
-                            10
-                        ],
-                        "text": "おこな"
-                    }
-                },
-                {
-                    "type": "lint",
-                    "ruleId": "prh",
-                    "message": "な => おこな",
+                    "message": "行 => おこな",
                     "index": 12,
                     "line": 1,
                     "column": 13,
@@ -112,7 +96,7 @@ tester.run("prh", rule, {
                 {
                     "type": "lint",
                     "ruleId": "prh",
-                    "message": "こ => おこな",
+                    "message": "行 => おこな",
                     "index": 16,
                     "line": 1,
                     "column": 17,
@@ -128,7 +112,7 @@ tester.run("prh", rule, {
                 {
                     "type": "lint",
                     "ruleId": "prh",
-                    "message": "おこ => おこな",
+                    "message": "行な => おこな",
                     "index": 21,
                     "line": 1,
                     "column": 22,

--- a/test/prh-rule-tester-test.js
+++ b/test/prh-rule-tester-test.js
@@ -37,6 +37,14 @@ tester.run("prh", rule, {
                     column: 1
                 }
             ]
+        },
+        {
+            text: "行う、行なう、おこなう。行って、行わない、行ないます。",
+            output: "おこなう、おこなう、おこなう。おこなって、おこなわない、おこないます。",
+            options: {
+                "rulePaths": [__dirname + "/fixtures/prefer-regexp.yml"]
+            },
+            errors: [/* TODO */]
         }
     ]
 });


### PR DESCRIPTION
Add test case for `?=` RegExp.
Current behavior has bug.

Original Bug reports: https://gist.github.com/cu39/8999ef8d0794d47da30917aa9e287a6f#file-prh-yml-L9

先読み正規表現のときの挙動がバグっている。
具体的にはここでreturnされている。
https://github.com/azu/textlint-rule-prh/blob/67a43f989850521b820151a0a0b0afd7c161c924/src/prh-rule.js#L83

<del>prh側の置換実装を使ったりできるのかな?</del>
applyChangeSetを持ってきた実装を追加

## TODO

- [x] refactoring
- [x] add test cases